### PR TITLE
ci: adds unity tests to ci

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,49 @@
+#
+# Git attributes for Unity projects
+#
+# Compiled by the GameCI community under the MIT license - https://game.ci
+#
+# Latest version at https://gist.github.com/webbertakken/ff250a0d5e59a8aae961c2e509c07fbc
+#
+
+# Ensure that text files that any contributor introduces to the repository have their line endings normalized
+* text=auto
+
+# Increase probability of success for merging files with specific extensions
+*.cs diff=csharp
+
+# Macro attribute: Files with Unity's yaml format
+# linguist-generated means the file is ignored for the repository's language statistics and diffs are hidden by default.
+[attr]unity-yaml-file -text merge=unityyamlmerge linguist-generated
+
+# Unity files
+*.asmdef unity-yaml-file -linguist-generated
+*.anim unity-yaml-file
+*.asset unity-yaml-file
+*.brush unity-yaml-file
+*.controller unity-yaml-file
+*.flare unity-yaml-file
+*.fontsettings unity-yaml-file
+*.giparams unity-yaml-file
+*.guiskin unity-yaml-file
+*.mask unity-yaml-file
+*.mat unity-yaml-file
+*.meta unity-yaml-file
+*.mixer unity-yaml-file
+*.overrideController unity-yaml-file
+*.physicMaterial unity-yaml-file
+*.physicsMaterial2D unity-yaml-file
+*.playable unity-yaml-file
+*.prefab unity-yaml-file
+*.preset unity-yaml-file
+*.renderTexture unity-yaml-file
+*.shadervariants unity-yaml-file
+*.spriteatlas unity-yaml-file
+*.terrainlayer unity-yaml-file
+*.unity unity-yaml-file
+
+# Noir Additions
+#=========================
+
 # Ignore all differences in line endings
 docs/*        -crlf

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,6 +80,32 @@ jobs:
           retention-days: 7
           path: ${{ env.NuGetDirectory }}/**/*.nupkg
 
+  #
+  # Test
+  # --------------------------------------------------------------------------------
+  # test handles running the playmode and editmode tests within Unity. This is done
+  # via the game-ci/unity-test-runner action
+  #
+  test:
+    runs-on: ubuntu-latest
+    needs: [ prep ]
+    permissions:
+      contents: write
+      issues: write
+      checks: write
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.FOSS_UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.FOSS_UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.FOSS_UNITY_PASSWORD }}
+        with:
+          projectPath: unity-project
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          unityVersion: ${{ needs.prep.outputs.unity_version }}
+
   # Deploy NuGet
   # --------------------------------------------------------------------------------
   # publishes any generated *.nupkg files to the Trouble Cat Studios GitHub account

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Ignore temporaries from GameCI
+/[Aa]rtifacts/
+/[Cc]odeCoverage/
+
 # Noir Additions
 #=========================
 unity-project/.data/


### PR DESCRIPTION
<!-- Please also consider adding yourself to CONTRIBUTORS.md as part of your pull request. We'd like to recognise you for your efforts! -->
<!-- Use the labels to mark what kind of PR you are submitting, bugfix? enhancement? docs? -->

## Overview

<!-- Please describe, in as much detail as you can, what your pull request changes. -->
<!-- Make sure to note what changes if any users might need to make in their application due to this PR? -->

- modifies `.gitattributes` and `.gitignore` with some [recommended settings](https://game.ci/docs/getting-started/) from the game-ci docs
- adds a `test` job to the build GitHub Action which uses `game-ci/unity-test-runner` to run the playmode and editmode tests within the `unity-project` directory

## Release Notes
<!-- Add any release notes for the changelog below -->
```release_note
- ci: adds automatic running of playmode and editmode tests via game-ci, see https://game.ci/docs/github/test-runner
```
