### PR TITLE
ci: adds api doc coverage % reporting to GHA build

### DIFF
--- a/.github/build/Noir.csproj
+++ b/.github/build/Noir.csproj
@@ -19,16 +19,16 @@
 
   <ItemGroup>
     <!-- include supporting package files -->
-    <None Include="$(RepoRoot)README.md" Pack="true" PackagePath=""/>
-    <None Include="$(RepoRoot)package/LICENSE.md" Pack="true" PackagePath=""/>
+    <None Include="../../README.md" Pack="true" PackagePath=""/>
+    <None Include="../../package/LICENSE.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(RepoRoot)package/Runtime/Noir/**/*.cs" />
+    <Compile Include="../../package/Runtime/Noir/**/*.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>$(RepoRoot)package/Vendor/Newtonsoft.Json.dll</HintPath>
+      <HintPath>../../package/Vendor/Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,14 +107,13 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           unityVersion: ${{ needs.prep.outputs.unity_version }}
 
-
   #
-  # Best Practices
+  # API Docs Coverage
   # --------------------------------------------------------------------------------
-  # this handles ensuring that the PR and the repository are meeting our project
-  # standards.
+  # this check verifies that the publicly accessible classes and members within our
+  # libraries have documentation comments added to them.
   #
-  best_practices:
+  api_docs_coverage:
     runs-on: ubuntu-latest
     needs: [prep]
     container:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,6 +106,36 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           unityVersion: ${{ needs.prep.outputs.unity_version }}
 
+
+  #
+  # Best Practices
+  # --------------------------------------------------------------------------------
+  # this handles ensuring that the PR and the repository are meeting our project
+  # standards.
+  #
+  best_practices:
+    runs-on: ubuntu-latest
+    needs: [prep]
+    strategy:
+      matrix:
+        project: ['Noir.csproj', 'NoirEditor.csproj']
+    permissions:
+      checks: write
+      statuses: write
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Run Cranky
+      id: docblocks
+      run: dotnet tool update cranky -g && cranky --project ./.github/build/${{ matrix.project }} --github --set-exit-code --percentages 65,95
+    - uses: mshick/add-pr-comment@v2
+      if: always()
+      with:
+        message-id: api_doc_cov
+        message: "Public API documentation coverage: ${{ steps.docblocks.outputs.percent }}%"
+
   # Deploy NuGet
   # --------------------------------------------------------------------------------
   # publishes any generated *.nupkg files to the Trouble Cat Studios GitHub account

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,7 +150,7 @@ jobs:
         export PATH="$PATH:/github/home/.dotnet/tools"
         cranky --project .github/build/${{ matrix.project }}.csproj --github --set-exit-code --percentages ${{ env.CRANKY_MIN_COVERAGE }},95
     - uses: mshick/add-pr-comment@v2
-      if: steps.cranky.outcome == failure()
+      if: always() && steps.cranky.outcome == failure()
       with:
         message-id: api_doc_cov-${{ matrix.project }}
         message: |
@@ -160,7 +160,7 @@ jobs:
           **Documented API Members**: ${{ steps.cranky.outputs.documented }}
           **Undocumented API Members**: ${{ steps.cranky.outputs.undocumented }}
     - uses: mshick/add-pr-comment@v2
-      if: steps.cranky.outcome == success()
+      if: always() && steps.cranky.outcome == success()
       with:
         message-id: api_doc_cov-${{ matrix.project }}
         message: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -116,6 +116,8 @@ jobs:
   best_practices:
     runs-on: ubuntu-latest
     needs: [prep]
+    container:
+      image: unityci/editor:ubuntu-${{ needs.prep.outputs.unity_version }}-base-3.1.0
     strategy:
       matrix:
         project: ['Noir.csproj', 'NoirEditor.csproj']

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,7 +120,7 @@ jobs:
       image: unityci/editor:ubuntu-${{ needs.prep.outputs.unity_version }}-base-3.1.0
     strategy:
       matrix:
-        project: ['Noir.csproj', 'NoirEditor.csproj']
+        project: ['Noir', 'NoirEditor']
     permissions:
       checks: write
       statuses: write
@@ -143,12 +143,15 @@ jobs:
         dotnet build ./NoirEditor.csproj
     - name: Run Cranky
       id: docblocks
-      run: dotnet tool update cranky -g && cranky --project .github/build/${{ matrix.project }} --github --set-exit-code --percentages 65,95
+      shell: bash
+      run: |
+        dotnet tool update cranky -g
+        dotnet tool run cranky --project .github/build/${{ matrix.project }}.csproj --github --set-exit-code --percentages 65,95
     - uses: mshick/add-pr-comment@v2
       if: always()
       with:
-        message-id: api_doc_cov
-        message: "Public API documentation coverage: ${{ steps.docblocks.outputs.percent }}%"
+        message-id: api_doc_cov-${{ matrix.project }}
+        message: "Public API documentation coverage for ${{ matrix.project }}: ${{ steps.docblocks.outputs.percent }}%"
 
   # Deploy NuGet
   # --------------------------------------------------------------------------------

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -144,6 +144,7 @@ jobs:
         dotnet build ./${{ matrix.project }}.csproj
     - name: Run Cranky
       id: cranky
+      continue-on-error: true
       shell: bash
       run: |
         dotnet tool update cranky -g

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,6 +127,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Mark repository as safe
+      shell: bash
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+    - uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: .github/build/global.json
     - name: Run Cranky
       id: docblocks
       run: dotnet tool update cranky -g && cranky --project ./.github/build/${{ matrix.project }} --github --set-exit-code --percentages 65,95

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,6 +133,12 @@ jobs:
     - uses: actions/setup-dotnet@v4
       with:
         global-json-file: .github/build/global.json
+    - name: Build code and create NuGet packages
+      shell: bash
+      run: |
+        cd ./.github/build
+        dotnet build ./Noir.csproj
+        dotnet build ./NoirEditor.csproj
     - name: Run Cranky
       id: docblocks
       run: dotnet tool update cranky -g && cranky --project .github/build/${{ matrix.project }} --github --set-exit-code --percentages 65,95

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -144,14 +144,13 @@ jobs:
         dotnet build ./${{ matrix.project }}.csproj
     - name: Run Cranky
       id: cranky
-      continue-on-error: true
       shell: bash
       run: |
         dotnet tool update cranky -g
         export PATH="$PATH:/github/home/.dotnet/tools"
         cranky --project .github/build/${{ matrix.project }}.csproj --github --set-exit-code --percentages ${{ env.CRANKY_MIN_COVERAGE }},95
     - uses: mshick/add-pr-comment@v2
-      if: always() && steps.cranky.outcome == failure()
+      if: failure()
       with:
         message-id: api_doc_cov-${{ matrix.project }}
         message: |
@@ -161,7 +160,7 @@ jobs:
           **Documented API Members**: ${{ steps.cranky.outputs.documented }}
           **Undocumented API Members**: ${{ steps.cranky.outputs.undocumented }}
     - uses: mshick/add-pr-comment@v2
-      if: always() && steps.cranky.outcome == success()
+      if: success()
       with:
         message-id: api_doc_cov-${{ matrix.project }}
         message: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,6 +119,7 @@ jobs:
     container:
       image: unityci/editor:ubuntu-${{ needs.prep.outputs.unity_version }}-base-3.1.0
     strategy:
+      fail-fast: false
       matrix:
         project: ['Noir', 'NoirEditor']
     permissions:
@@ -135,6 +136,11 @@ jobs:
     - uses: actions/setup-dotnet@v4
       with:
         global-json-file: .github/build/global.json
+    - name: Build ${{ matrix.project }}.csproj
+      shell: bash
+      run: |
+        cd ./.github/build
+        dotnet build ./${{ matrix.project }}.csproj
     - name: Run Cranky
       id: docblocks
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,7 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
   NuGetDirectory: ${{ github.workspace}}/.build/nuget
+  CRANKY_MIN_COVERAGE: 65
 
 jobs:
   #
@@ -142,17 +143,33 @@ jobs:
         cd ./.github/build
         dotnet build ./${{ matrix.project }}.csproj
     - name: Run Cranky
-      id: docblocks
+      id: cranky
       shell: bash
       run: |
         dotnet tool update cranky -g
         export PATH="$PATH:/github/home/.dotnet/tools"
-        cranky --project .github/build/${{ matrix.project }}.csproj --github --set-exit-code --percentages 65,95
+        cranky --project .github/build/${{ matrix.project }}.csproj --github --set-exit-code --percentages ${{ env.CRANKY_MIN_COVERAGE }},95
     - uses: mshick/add-pr-comment@v2
-      if: always()
+      if: steps.cranky.outcome == failure()
       with:
         message-id: api_doc_cov-${{ matrix.project }}
-        message: "Public API documentation coverage for ${{ matrix.project }}: ${{ steps.docblocks.outputs.percent }}%"
+        message: |
+          > [!WARNING]
+          > ${{ steps.cranky.outputs.health }} The public API documentation coverage for ${{ matrix.project }} (${{ steps.cranky.outputs.percent }}%) is below the minimum threshold ${{ env.CRANKY_MIN_COVERAGE }}%
+
+          **Documented API Members**: ${{ steps.cranky.outputs.documented }}
+          **Undocumented API Members**: ${{ steps.cranky.outputs.undocumented }}
+    - uses: mshick/add-pr-comment@v2
+      if: steps.cranky.outcome == success()
+      with:
+        message-id: api_doc_cov-${{ matrix.project }}
+        message: |
+          > [!TIP]
+          > ${{ steps.cranky.outputs.health }} The public API documentation coverage for ${{ matrix.project }} (${{ steps.cranky.outputs.percent }}%) is above the minimum threshold ${{ env.CRANKY_MIN_COVERAGE }}%
+
+          **Documented API Members**: ${{ steps.cranky.outputs.documented }}
+          **Undocumented API Members**: ${{ steps.cranky.outputs.undocumented }}
+
 
   # Deploy NuGet
   # --------------------------------------------------------------------------------

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -155,7 +155,7 @@ jobs:
         message-id: api_doc_cov-${{ matrix.project }}
         message: |
           > [!WARNING]
-          > ${{ steps.cranky.outputs.health }} The public API documentation coverage for ${{ matrix.project }} (${{ steps.cranky.outputs.percent }}%) is below the minimum threshold ${{ env.CRANKY_MIN_COVERAGE }}%
+          > ${{ steps.cranky.outputs.health }} The public API documentation coverage for ${{ matrix.project }} (${{ steps.cranky.outputs.percent }}%) is below the minimum threshold of ${{ env.CRANKY_MIN_COVERAGE }}%
 
           **Documented API Members**: ${{ steps.cranky.outputs.documented }}
           **Undocumented API Members**: ${{ steps.cranky.outputs.undocumented }}
@@ -165,7 +165,7 @@ jobs:
         message-id: api_doc_cov-${{ matrix.project }}
         message: |
           > [!TIP]
-          > ${{ steps.cranky.outputs.health }} The public API documentation coverage for ${{ matrix.project }} (${{ steps.cranky.outputs.percent }}%) is above the minimum threshold ${{ env.CRANKY_MIN_COVERAGE }}%
+          > ${{ steps.cranky.outputs.health }} The public API documentation coverage for ${{ matrix.project }} (${{ steps.cranky.outputs.percent }}%) is above the minimum threshold of ${{ env.CRANKY_MIN_COVERAGE }}%
 
           **Documented API Members**: ${{ steps.cranky.outputs.documented }}
           **Undocumented API Members**: ${{ steps.cranky.outputs.undocumented }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,18 +135,13 @@ jobs:
     - uses: actions/setup-dotnet@v4
       with:
         global-json-file: .github/build/global.json
-    - name: Build code and create NuGet packages
-      shell: bash
-      run: |
-        cd ./.github/build
-        dotnet build ./Noir.csproj
-        dotnet build ./NoirEditor.csproj
     - name: Run Cranky
       id: docblocks
       shell: bash
       run: |
         dotnet tool update cranky -g
-        dotnet tool run cranky --project .github/build/${{ matrix.project }}.csproj --github --set-exit-code --percentages 65,95
+        export PATH="$PATH:/github/home/.dotnet/tools"
+        cranky --project .github/build/${{ matrix.project }}.csproj --github --set-exit-code --percentages 65,95
     - uses: mshick/add-pr-comment@v2
       if: always()
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,7 +135,7 @@ jobs:
         global-json-file: .github/build/global.json
     - name: Run Cranky
       id: docblocks
-      run: dotnet tool update cranky -g && cranky --project ./.github/build/${{ matrix.project }} --github --set-exit-code --percentages 65,95
+      run: dotnet tool update cranky -g && cranky --project .github/build/${{ matrix.project }} --github --set-exit-code --percentages 65,95
     - uses: mshick/add-pr-comment@v2
       if: always()
       with:

--- a/docs/reference/Noir/BezierCurveMovement.md
+++ b/docs/reference/Noir/BezierCurveMovement.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Represents movement along a Bezier curve over a specified duration.
+
 
 ```csharp
 public class BezierCurveMovement
@@ -30,6 +32,8 @@ public BezierCurveMovement()
 <!-- tc:scope public -->
 <!-- tc:return_type BezierCurve /noir/reference/Noir/BezierCurve/ -->
 <!-- tc:version 1.0.0 -->
+Gets or sets the Bezier curve to use for movement.
+
 
 ```csharp
 public BezierCurve Curve { get; public set; }
@@ -42,6 +46,8 @@ public BezierCurve Curve { get; public set; }
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Gets or sets the duration of the movement along the curve, in seconds.
+
 
 ```csharp
 public float Duration { get; public set; }

--- a/docs/reference/Noir/Collections.md
+++ b/docs/reference/Noir/Collections.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Provides extension methods and utilities for working with collections.
+
 
 ```csharp
 public static class Collections

--- a/docs/reference/Noir/Collider2DExtensions.md
+++ b/docs/reference/Noir/Collider2DExtensions.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Extension methods for Unity [Collider2D](https://docs.unity3d.com/ScriptReference/Collider2D.html) components.
+
 
 ```csharp
 public static class Collider2DExtensions
@@ -16,6 +18,10 @@ public static class Collider2DExtensions
 ### `SetDimensions(Collider2D, Vector2)`
 <!-- tc:scope public -->
 <!-- tc:version 1.0.0 -->
+Sets the dimensions of the 2D collider based on the specified size.
+            The behavior depends on the specific collider type:
+            <list type="bullet"><item>[PolygonCollider2D](https://docs.unity3d.com/ScriptReference/PolygonCollider2D.html): Throws an exception as dimensions cannot be set directly.</item></list>
+
 
 ```csharp
 public void SetDimensions(Collider2D collider, Vector2 size)
@@ -24,5 +30,13 @@ public void SetDimensions(Collider2D collider, Vector2 size)
 
 **Parameters** <br>
 `collider` [Collider2D](https://docs.unity3d.com/ScriptReference/Collider2D.html) <br>
+ <br>
 `size` [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) <br>
+ <br>
 
+**Exceptions** <br>
+[InvalidOperationException](https://learn.microsoft.com/en-us/dotnet/api/System.InvalidOperationException?view=net-7.0) <br>
+ <br>
+## More information
+
+* [UnityEngine.Collider2D](https://docs.unity3d.com/ScriptReference/Collider2D.html)

--- a/docs/reference/Noir/ColliderExtensions.md
+++ b/docs/reference/Noir/ColliderExtensions.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Extension methods for Unity [Collider](https://docs.unity3d.com/ScriptReference/Collider.html) components.
+
 
 ```csharp
 public static class ColliderExtensions
@@ -16,6 +18,10 @@ public static class ColliderExtensions
 ### `SetDimensions(Collider, Vector2)`
 <!-- tc:scope public -->
 <!-- tc:version 1.0.0 -->
+Sets the dimensions of the collider based on the specified size.
+            The behavior depends on the specific collider type:
+            <list type="bullet"><item>[CapsuleCollider](https://docs.unity3d.com/ScriptReference/CapsuleCollider.html): Sets the radius to x and the height to y.</item></list>
+
 
 ```csharp
 public void SetDimensions(Collider collider, Vector2 size)
@@ -24,5 +30,13 @@ public void SetDimensions(Collider collider, Vector2 size)
 
 **Parameters** <br>
 `collider` [Collider](https://docs.unity3d.com/ScriptReference/Collider.html) <br>
+ <br>
 `size` [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) <br>
+ <br>
 
+**Exceptions** <br>
+[InvalidOperationException](https://learn.microsoft.com/en-us/dotnet/api/System.InvalidOperationException?view=net-7.0) <br>
+ <br>
+## More information
+
+* [UnityEngine.Collider](https://docs.unity3d.com/ScriptReference/Collider.html)

--- a/docs/reference/Noir/ColorExtensions.md
+++ b/docs/reference/Noir/ColorExtensions.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Extension methods for the [Color](https://docs.unity3d.com/ScriptReference/Color.html) type, including blending, vector conversion, and utility operations.
+
 
 ```csharp
 public static class ColorExtensions
@@ -34,6 +36,8 @@ public Color BlendWith(Color a, Color b, ColorBlendMode mode)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Darkens the color by blending with another color.
+
 
 ```csharp
 public Color Darken(Color a, Color b)
@@ -42,7 +46,9 @@ public Color Darken(Color a, Color b)
 
 **Parameters** <br>
 `a` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `b` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="Darken"></a>
 
@@ -50,6 +56,8 @@ public Color Darken(Color a, Color b)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Darkens the color by blending with black at 50% alpha.
+
 
 ```csharp
 public Color Darken(Color a)
@@ -58,6 +66,7 @@ public Color Darken(Color a)
 
 **Parameters** <br>
 `a` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="Difference"></a>
 
@@ -65,6 +74,8 @@ public Color Darken(Color a)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Applies a difference blend between two colors.
+
 
 ```csharp
 public Color Difference(Color a, Color b)
@@ -73,7 +84,9 @@ public Color Difference(Color a, Color b)
 
 **Parameters** <br>
 `a` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `b` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="Exclusion"></a>
 
@@ -81,6 +94,8 @@ public Color Difference(Color a, Color b)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Applies an exclusion blend between two colors.
+
 
 ```csharp
 public Color Exclusion(Color a, Color b)
@@ -89,7 +104,9 @@ public Color Exclusion(Color a, Color b)
 
 **Parameters** <br>
 `a` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `b` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="HardLight"></a>
 
@@ -97,6 +114,8 @@ public Color Exclusion(Color a, Color b)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Applies a hard light blend between two colors.
+
 
 ```csharp
 public Color HardLight(Color a, Color b)
@@ -105,7 +124,9 @@ public Color HardLight(Color a, Color b)
 
 **Parameters** <br>
 `a` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `b` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="Lighten"></a>
 
@@ -113,6 +134,8 @@ public Color HardLight(Color a, Color b)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Lightens the color by blending with another color.
+
 
 ```csharp
 public Color Lighten(Color a, Color b)
@@ -121,7 +144,9 @@ public Color Lighten(Color a, Color b)
 
 **Parameters** <br>
 `a` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `b` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="Lighten"></a>
 
@@ -129,6 +154,8 @@ public Color Lighten(Color a, Color b)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Lightens the color by blending with white at 50% alpha.
+
 
 ```csharp
 public Color Lighten(Color a)
@@ -137,6 +164,7 @@ public Color Lighten(Color a)
 
 **Parameters** <br>
 `a` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="MaxWith"></a>
 
@@ -144,6 +172,8 @@ public Color Lighten(Color a)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Returns a new color with the maximum values from each channel of two colors.
+
 
 ```csharp
 public Color MaxWith(Color c1, Color c2)
@@ -152,7 +182,9 @@ public Color MaxWith(Color c1, Color c2)
 
 **Parameters** <br>
 `c1` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `c2` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="MinWith"></a>
 
@@ -160,6 +192,8 @@ public Color MaxWith(Color c1, Color c2)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Returns a new color with the minimum values from each channel of two colors.
+
 
 ```csharp
 public Color MinWith(Color c1, Color c2)
@@ -168,7 +202,9 @@ public Color MinWith(Color c1, Color c2)
 
 **Parameters** <br>
 `c1` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `c2` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="Overlay"></a>
 
@@ -176,6 +212,8 @@ public Color MinWith(Color c1, Color c2)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Applies an overlay blend between two colors.
+
 
 ```csharp
 public Color Overlay(Color a, Color b)
@@ -184,7 +222,9 @@ public Color Overlay(Color a, Color b)
 
 **Parameters** <br>
 `a` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `b` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="SoftLight"></a>
 
@@ -192,6 +232,8 @@ public Color Overlay(Color a, Color b)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Applies a soft light blend between two colors.
+
 
 ```csharp
 public Color SoftLight(Color a, Color b)
@@ -200,7 +242,9 @@ public Color SoftLight(Color a, Color b)
 
 **Parameters** <br>
 `a` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `b` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="ToColor"></a>
 
@@ -208,6 +252,8 @@ public Color SoftLight(Color a, Color b)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Converts a [Color](https://docs.unity3d.com/ScriptReference/Color.html).
+
 
 ```csharp
 public Color ToColor(Vector4 vector)
@@ -216,6 +262,7 @@ public Color ToColor(Vector4 vector)
 
 **Parameters** <br>
 `vector` [Vector4](https://docs.unity3d.com/ScriptReference/Vector4.html) <br>
+ <br>
 
 <a name="WithAlpha"></a>
 
@@ -223,6 +270,8 @@ public Color ToColor(Vector4 vector)
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Returns a new color with the alpha channel set to the specified value.
+
 
 ```csharp
 public Color WithAlpha(Color color, float alpha)
@@ -231,7 +280,9 @@ public Color WithAlpha(Color color, float alpha)
 
 **Parameters** <br>
 `color` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `alpha` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 
 <a name="FadeTo"></a>
 
@@ -239,6 +290,8 @@ public Color WithAlpha(Color color, float alpha)
 <!-- tc:scope public -->
 <!-- tc:return_type IEnumerator https://learn.microsoft.com/en-us/dotnet/api/System.Collections.IEnumerator?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Fades a color to another color over the specified duration, yielding after each frame.
+
 
 ```csharp
 public IEnumerator FadeTo(Color color, Color colorb, float duration)
@@ -247,8 +300,11 @@ public IEnumerator FadeTo(Color color, Color colorb, float duration)
 
 **Parameters** <br>
 `color` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `colorb` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `duration` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 
 <a name="XW"></a>
 
@@ -256,6 +312,8 @@ public IEnumerator FadeTo(Color color, Color colorb, float duration)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the red and alpha channels.
+
 
 ```csharp
 public Vector2 XW(Color c)
@@ -271,6 +329,8 @@ public Vector2 XW(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the red channel twice.
+
 
 ```csharp
 public Vector2 XX(Color c)
@@ -286,6 +346,8 @@ public Vector2 XX(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the red and green channels.
+
 
 ```csharp
 public Vector2 XY(Color c)
@@ -301,6 +363,8 @@ public Vector2 XY(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the red and blue channels.
+
 
 ```csharp
 public Vector2 XZ(Color c)
@@ -316,6 +380,8 @@ public Vector2 XZ(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the green and alpha channels.
+
 
 ```csharp
 public Vector2 YW(Color c)
@@ -331,6 +397,8 @@ public Vector2 YW(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the green and red channels.
+
 
 ```csharp
 public Vector2 YX(Color c)
@@ -346,6 +414,8 @@ public Vector2 YX(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the green channel twice.
+
 
 ```csharp
 public Vector2 YY(Color c)
@@ -361,6 +431,8 @@ public Vector2 YY(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the green and blue channels.
+
 
 ```csharp
 public Vector2 YZ(Color c)
@@ -376,6 +448,8 @@ public Vector2 YZ(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the blue and alpha channels.
+
 
 ```csharp
 public Vector2 ZW(Color c)
@@ -391,6 +465,8 @@ public Vector2 ZW(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the blue and red channels.
+
 
 ```csharp
 public Vector2 ZX(Color c)
@@ -406,6 +482,8 @@ public Vector2 ZX(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the blue and green channels.
+
 
 ```csharp
 public Vector2 ZY(Color c)
@@ -421,6 +499,8 @@ public Vector2 ZY(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector2 https://docs.unity3d.com/ScriptReference/Vector2.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) containing the blue channel twice.
+
 
 ```csharp
 public Vector2 ZZ(Color c)
@@ -436,6 +516,8 @@ public Vector2 ZZ(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector3 https://docs.unity3d.com/ScriptReference/Vector3.html -->
 <!-- tc:version 1.0.0 -->
+Converts a color to a [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) using its RGBA channels.
+
 
 ```csharp
 public Vector3 ToVector3(Color c)
@@ -444,6 +526,7 @@ public Vector3 ToVector3(Color c)
 
 **Parameters** <br>
 `c` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="XXX"></a>
 
@@ -451,6 +534,8 @@ public Vector3 ToVector3(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector3 https://docs.unity3d.com/ScriptReference/Vector3.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) containing the red channel three times.
+
 
 ```csharp
 public Vector3 XXX(Color c)
@@ -466,6 +551,8 @@ public Vector3 XXX(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector3 https://docs.unity3d.com/ScriptReference/Vector3.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) containing the red, green, and blue channels.
+
 
 ```csharp
 public Vector3 XYZ(Color c)
@@ -481,6 +568,8 @@ public Vector3 XYZ(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector3 https://docs.unity3d.com/ScriptReference/Vector3.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) containing the green channel three times.
+
 
 ```csharp
 public Vector3 YYY(Color c)
@@ -496,6 +585,8 @@ public Vector3 YYY(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector3 https://docs.unity3d.com/ScriptReference/Vector3.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) containing the blue channel three times.
+
 
 ```csharp
 public Vector3 ZZZ(Color c)
@@ -511,6 +602,8 @@ public Vector3 ZZZ(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector4 https://docs.unity3d.com/ScriptReference/Vector4.html -->
 <!-- tc:version 1.0.0 -->
+Converts a [Vector4](https://docs.unity3d.com/ScriptReference/Vector4.html).
+
 
 ```csharp
 public Vector4 ToVector4(Color color)
@@ -519,6 +612,7 @@ public Vector4 ToVector4(Color color)
 
 **Parameters** <br>
 `color` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 
 <a name="XXXX"></a>
 
@@ -526,6 +620,8 @@ public Vector4 ToVector4(Color color)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector4 https://docs.unity3d.com/ScriptReference/Vector4.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector4](https://docs.unity3d.com/ScriptReference/Vector4.html) containing the red channel four times.
+
 
 ```csharp
 public Vector4 XXXX(Color c)
@@ -541,6 +637,8 @@ public Vector4 XXXX(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector4 https://docs.unity3d.com/ScriptReference/Vector4.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector4](https://docs.unity3d.com/ScriptReference/Vector4.html) containing the green channel four times.
+
 
 ```csharp
 public Vector4 YYYY(Color c)
@@ -556,6 +654,8 @@ public Vector4 YYYY(Color c)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector4 https://docs.unity3d.com/ScriptReference/Vector4.html -->
 <!-- tc:version 1.0.0 -->
+Gets a [Vector4](https://docs.unity3d.com/ScriptReference/Vector4.html) containing the blue channel four times.
+
 
 ```csharp
 public Vector4 ZZZZ(Color c)
@@ -565,3 +665,6 @@ public Vector4 ZZZZ(Color c)
 **Parameters** <br>
 `c` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
 
+## More information
+
+* [UnityEngine.Color](https://docs.unity3d.com/ScriptReference/Color.html)

--- a/docs/reference/Noir/DictionaryExtensions.md
+++ b/docs/reference/Noir/DictionaryExtensions.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Provides extension methods for performing upsert operations on [Dictionary<TKey, TValue>](https://learn.microsoft.com/en-us/dotnet/api/System.Collections.Generic.Dictionary-2?view=net-7.0).
+
 
 ```csharp
 public static class DictionaryExtensions
@@ -61,3 +63,6 @@ public void Upsert(Dictionary<TKey, TValue> target, IDictionary<TKey,
 `target` [Dictionary\<TKey, TValue\>](https://learn.microsoft.com/en-us/dotnet/api/System.Collections.Generic.Dictionary-2?view=net-7.0) <br>
 `source` [IDictionary\<TKey, TValue\>](https://learn.microsoft.com/en-us/dotnet/api/System.Collections.Generic.IDictionary-2?view=net-7.0) <br>
 
+## More information
+
+* [System.Collections.Generic.Dictionary`2](https://learn.microsoft.com/en-us/dotnet/api/System.Collections.Generic.Dictionary-2?view=net-7.0)

--- a/docs/reference/Noir/Direction.md
+++ b/docs/reference/Noir/Direction.md
@@ -117,6 +117,8 @@ public VerticalDirections Vertical { get; private set; }
 <!-- tc:scope public -->
 <!-- tc:return_type bool https://learn.microsoft.com/en-us/dotnet/api/System.Boolean?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Determines whether this instance and another [Direction](/noir/reference/Noir/Direction/) are equal.
+
 
 ```csharp
 public virtual bool Equals(Direction other)
@@ -125,6 +127,7 @@ public virtual bool Equals(Direction other)
 
 **Parameters** <br>
 `other` [Direction](/noir/reference/Noir/Direction/) <br>
+ <br>
 
 <a name="Equals"></a>
 
@@ -132,6 +135,8 @@ public virtual bool Equals(Direction other)
 <!-- tc:scope public -->
 <!-- tc:return_type bool https://learn.microsoft.com/en-us/dotnet/api/System.Boolean?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Determines whether this instance and a specified object are equal.
+
 
 ```csharp
 public virtual bool Equals(Object obj)
@@ -140,6 +145,7 @@ public virtual bool Equals(Object obj)
 
 **Parameters** <br>
 `obj` [Object](https://learn.microsoft.com/en-us/dotnet/api/System.Object?view=net-7.0) <br>
+ <br>
 
 <a name="GetHashCode"></a>
 
@@ -147,6 +153,8 @@ public virtual bool Equals(Object obj)
 <!-- tc:scope public -->
 <!-- tc:return_type int https://learn.microsoft.com/en-us/dotnet/api/System.Int32?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Returns the hash code for this instance.
+
 
 ```csharp
 public virtual int GetHashCode()

--- a/docs/reference/Noir/EaseType.md
+++ b/docs/reference/Noir/EaseType.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Specifies the different types of easing functions for interpolation.
+
 
 ```csharp
 public sealed enum EaseType : Enum, IComparable, ISpanFormattable, IFormattable, IConvertible

--- a/docs/reference/Noir/Easing.md
+++ b/docs/reference/Noir/Easing.md
@@ -4,7 +4,7 @@
 
 <!-- tc:assembly Noir.dll -->
 
-Easing functions to be used for interpolation
+Provides easing functions for interpolation of various types.
 
 
 ```csharp
@@ -19,6 +19,8 @@ public static class Easing
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Interpolates between two [Color](https://docs.unity3d.com/ScriptReference/Color.html) values using the specified easing type.
+
 
 ```csharp
 public Color Ease(EaseType type, Color from, Color to, float t)
@@ -27,9 +29,13 @@ public Color Ease(EaseType type, Color from, Color to, float t)
 
 **Parameters** <br>
 `type` [EaseType](/noir/reference/Noir/EaseType/) <br>
+ <br>
 `from` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `to` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `t` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 
 <a name="BackIn"></a>
 
@@ -37,6 +43,8 @@ public Color Ease(EaseType type, Color from, Color to, float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Back in easing.
+
 
 ```csharp
 public float BackIn(float t)
@@ -52,6 +60,8 @@ public float BackIn(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Back in-out easing.
+
 
 ```csharp
 public float BackInOut(float t)
@@ -67,6 +77,8 @@ public float BackInOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Back out easing.
+
 
 ```csharp
 public float BackOut(float t)
@@ -82,6 +94,8 @@ public float BackOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Bounce in easing.
+
 
 ```csharp
 public float BounceIn(float t)
@@ -97,6 +111,8 @@ public float BounceIn(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Bounce in-out easing.
+
 
 ```csharp
 public float BounceInOut(float t)
@@ -112,6 +128,8 @@ public float BounceInOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Bounce out easing.
+
 
 ```csharp
 public float BounceOut(float t)
@@ -127,6 +145,8 @@ public float BounceOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Circular in easing.
+
 
 ```csharp
 public float CircularIn(float t)
@@ -142,6 +162,8 @@ public float CircularIn(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Circular in-out easing.
+
 
 ```csharp
 public float CircularInOut(float t)
@@ -157,6 +179,8 @@ public float CircularInOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Circular out easing.
+
 
 ```csharp
 public float CircularOut(float t)
@@ -172,6 +196,8 @@ public float CircularOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Cubic in easing (accelerating from zero velocity).
+
 
 ```csharp
 public float CubicIn(float t)
@@ -187,6 +213,8 @@ public float CubicIn(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Cubic in-out easing (acceleration until halfway, then deceleration).
+
 
 ```csharp
 public float CubicInOut(float t)
@@ -202,6 +230,8 @@ public float CubicInOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Cubic out easing (decelerating to zero velocity).
+
 
 ```csharp
 public float CubicOut(float t)
@@ -217,6 +247,8 @@ public float CubicOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Interpolates between two float values using the specified easing type.
+
 
 ```csharp
 public float Ease(EaseType type, float from, float to, float t)
@@ -225,9 +257,13 @@ public float Ease(EaseType type, float from, float to, float t)
 
 **Parameters** <br>
 `type` [EaseType](/noir/reference/Noir/EaseType/) <br>
+ <br>
 `from` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 `to` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 `t` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 
 <a name="ElasticIn"></a>
 
@@ -235,6 +271,8 @@ public float Ease(EaseType type, float from, float to, float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Elastic in easing.
+
 
 ```csharp
 public float ElasticIn(float t)
@@ -250,6 +288,8 @@ public float ElasticIn(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Elastic in-out easing.
+
 
 ```csharp
 public float ElasticInOut(float t)
@@ -265,6 +305,8 @@ public float ElasticInOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Elastic out easing.
+
 
 ```csharp
 public float ElasticOut(float t)
@@ -280,6 +322,8 @@ public float ElasticOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Exponential in easing.
+
 
 ```csharp
 public float ExponentialIn(float t)
@@ -295,6 +339,8 @@ public float ExponentialIn(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Exponential in-out easing.
+
 
 ```csharp
 public float ExponentialInOut(float t)
@@ -310,6 +356,8 @@ public float ExponentialInOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Exponential out easing.
+
 
 ```csharp
 public float ExponentialOut(float t)
@@ -325,6 +373,8 @@ public float ExponentialOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Linear easing (no acceleration).
+
 
 ```csharp
 public float Linear(float t)
@@ -340,6 +390,8 @@ public float Linear(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Quadratic in easing (accelerating from zero velocity).
+
 
 ```csharp
 public float QuadraticIn(float t)
@@ -355,6 +407,8 @@ public float QuadraticIn(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Quadratic in-out easing (acceleration until halfway, then deceleration).
+
 
 ```csharp
 public float QuadraticInOut(float t)
@@ -370,6 +424,8 @@ public float QuadraticInOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Quadratic out easing (decelerating to zero velocity).
+
 
 ```csharp
 public float QuadraticOut(float t)
@@ -385,6 +441,8 @@ public float QuadraticOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Quartic in easing (accelerating from zero velocity).
+
 
 ```csharp
 public float QuarticIn(float t)
@@ -400,6 +458,8 @@ public float QuarticIn(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Quartic in-out easing (acceleration until halfway, then deceleration).
+
 
 ```csharp
 public float QuarticInOut(float t)
@@ -415,6 +475,8 @@ public float QuarticInOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Quartic out easing (decelerating to zero velocity).
+
 
 ```csharp
 public float QuarticOut(float t)
@@ -430,6 +492,8 @@ public float QuarticOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Quintic in easing (accelerating from zero velocity).
+
 
 ```csharp
 public float QuinticIn(float t)
@@ -445,6 +509,8 @@ public float QuinticIn(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Quintic in-out easing (acceleration until halfway, then deceleration).
+
 
 ```csharp
 public float QuinticInOut(float t)
@@ -460,6 +526,8 @@ public float QuinticInOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Quintic out easing (decelerating to zero velocity).
+
 
 ```csharp
 public float QuinticOut(float t)
@@ -475,6 +543,8 @@ public float QuinticOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Sinusoidal in easing.
+
 
 ```csharp
 public float SinusoidalIn(float t)
@@ -490,6 +560,8 @@ public float SinusoidalIn(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Sinusoidal in-out easing.
+
 
 ```csharp
 public float SinusoidalInOut(float t)
@@ -505,6 +577,8 @@ public float SinusoidalInOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type float https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Sinusoidal out easing.
+
 
 ```csharp
 public float SinusoidalOut(float t)
@@ -520,6 +594,8 @@ public float SinusoidalOut(float t)
 <!-- tc:scope public -->
 <!-- tc:return_type Func\<T, TResult\> https://learn.microsoft.com/en-us/dotnet/api/System.Func-2?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Gets the easing function delegate for the specified [EaseType](/noir/reference/Noir/EaseType/).
+
 
 ```csharp
 public Func<T, TResult> Function(EaseType type)
@@ -528,6 +604,7 @@ public Func<T, TResult> Function(EaseType type)
 
 **Parameters** <br>
 `type` [EaseType](/noir/reference/Noir/EaseType/) <br>
+ <br>
 
 <a name="Ease"></a>
 
@@ -535,6 +612,8 @@ public Func<T, TResult> Function(EaseType type)
 <!-- tc:scope public -->
 <!-- tc:return_type Quaternion https://docs.unity3d.com/ScriptReference/Quaternion.html -->
 <!-- tc:version 1.0.0 -->
+Interpolates between two [Quaternion](https://docs.unity3d.com/ScriptReference/Quaternion.html) values using the specified easing type.
+
 
 ```csharp
 public Quaternion Ease(EaseType type, Quaternion from, Quaternion to, float t)
@@ -543,9 +622,13 @@ public Quaternion Ease(EaseType type, Quaternion from, Quaternion to, float t)
 
 **Parameters** <br>
 `type` [EaseType](/noir/reference/Noir/EaseType/) <br>
+ <br>
 `from` [Quaternion](https://docs.unity3d.com/ScriptReference/Quaternion.html) <br>
+ <br>
 `to` [Quaternion](https://docs.unity3d.com/ScriptReference/Quaternion.html) <br>
+ <br>
 `t` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 
 <a name="Ease"></a>
 
@@ -553,6 +636,8 @@ public Quaternion Ease(EaseType type, Quaternion from, Quaternion to, float t)
 <!-- tc:scope public -->
 <!-- tc:return_type Vector3 https://docs.unity3d.com/ScriptReference/Vector3.html -->
 <!-- tc:version 1.0.0 -->
+Interpolates between two [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) values using the specified easing type.
+
 
 ```csharp
 public Vector3 Ease(EaseType type, Vector3 from, Vector3 to, float t)
@@ -561,7 +646,11 @@ public Vector3 Ease(EaseType type, Vector3 from, Vector3 to, float t)
 
 **Parameters** <br>
 `type` [EaseType](/noir/reference/Noir/EaseType/) <br>
+ <br>
 `from` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `to` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `t` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 

--- a/docs/reference/Noir/GameObjectExtensions.md
+++ b/docs/reference/Noir/GameObjectExtensions.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Provides extension methods and utilities for working with GameObjects.
+
 
 ```csharp
 public static class GameObjectExtensions

--- a/docs/reference/Noir/NoirBehaviour.md
+++ b/docs/reference/Noir/NoirBehaviour.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Base class for Noir MonoBehaviour scripts, providing easy access to logging, time, services, and event dispatching.
+
 
 ```csharp
 public class NoirBehaviour : MonoBehaviour
@@ -32,6 +34,8 @@ public NoirBehaviour()
 <!-- tc:scope public -->
 <!-- tc:return_type string https://learn.microsoft.com/en-us/dotnet/api/System.String?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Returns a string representation of this behaviour, including its unique identifier.
+
 
 ```csharp
 public virtual string ToString()

--- a/docs/reference/Noir/NoirColor.md
+++ b/docs/reference/Noir/NoirColor.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Provides helper methods for creating [Color](https://docs.unity3d.com/ScriptReference/Color.html) objects.
+
 
 ```csharp
 public static class NoirColor
@@ -17,6 +19,8 @@ public static class NoirColor
 <!-- tc:scope public -->
 <!-- tc:return_type Color https://docs.unity3d.com/ScriptReference/Color.html -->
 <!-- tc:version 1.0.0 -->
+Creates a [Color](https://docs.unity3d.com/ScriptReference/Color.html) object from a hexadecimal color string.
+
 
 ```csharp
 public Color FromHex(string color)
@@ -25,4 +29,11 @@ public Color FromHex(string color)
 
 **Parameters** <br>
 `color` [string](https://learn.microsoft.com/en-us/dotnet/api/System.String?view=net-7.0) <br>
+ <br>
 
+**Exceptions** <br>
+[FormatException](https://learn.microsoft.com/en-us/dotnet/api/System.FormatException?view=net-7.0) <br>
+ <br>
+## More information
+
+* [UnityEngine.Color](https://docs.unity3d.com/ScriptReference/Color.html)

--- a/docs/reference/Noir/NoirEnum.md
+++ b/docs/reference/Noir/NoirEnum.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Provides helper methods for interacting with [Enum](https://learn.microsoft.com/en-us/dotnet/api/System.Enum?view=net-7.0) values.
+
 
 ```csharp
 public static class NoirEnum
@@ -17,9 +19,17 @@ public static class NoirEnum
 <!-- tc:scope public -->
 <!-- tc:return_type IEnumerable\<T\> https://learn.microsoft.com/en-us/dotnet/api/System.Collections.Generic.IEnumerable-1?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Returns an enumerable collection of all possible values of the specified enum type <typeparamref name="T" />.
+
 
 ```csharp
 public IEnumerable<T> AllValuesFor()
 
 ```
 
+**Exceptions** <br>
+[ArgumentException](https://learn.microsoft.com/en-us/dotnet/api/System.ArgumentException?view=net-7.0) <br>
+ <br>
+## More information
+
+* [System.Enum](https://learn.microsoft.com/en-us/dotnet/api/System.Enum?view=net-7.0)

--- a/docs/reference/Noir/NoirGizmos.md
+++ b/docs/reference/Noir/NoirGizmos.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Provides helper methods for drawing gizmos and handles in Unity editor and runtime.
+
 
 ```csharp
 public static class NoirGizmos
@@ -16,6 +18,8 @@ public static class NoirGizmos
 ### `DrawArrow(Vector3, Vector3, float, float)`
 <!-- tc:scope public -->
 <!-- tc:version 1.0.0 -->
+Draws an arrow gizmo at the given position and direction using the current Gizmos color.
+
 
 ```csharp
 public void DrawArrow(Vector3 pos, Vector3 direction, float arrowHeadLength,
@@ -26,15 +30,21 @@ public void DrawArrow(Vector3 pos, Vector3 direction, float arrowHeadLength,
 
 **Parameters** <br>
 `pos` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `direction` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `arrowHeadLength` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 `arrowHeadAngle` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 
 <a name="DrawArrow"></a>
 
 ### `DrawArrow(Vector3, Vector3, Color, float, float)`
 <!-- tc:scope public -->
 <!-- tc:version 1.0.0 -->
+Draws an arrow gizmo at the given position and direction, with a specified color.
+
 
 ```csharp
 public void DrawArrow(Vector3 pos, Vector3 direction, Color color,
@@ -45,16 +55,23 @@ public void DrawArrow(Vector3 pos, Vector3 direction, Color color,
 
 **Parameters** <br>
 `pos` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `direction` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `color` [Color](https://docs.unity3d.com/ScriptReference/Color.html) <br>
+ <br>
 `arrowHeadLength` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 `arrowHeadAngle` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 
 <a name="DrawBezierCurve"></a>
 
 ### `DrawBezierCurve(Vector3, BezierCurve, int, float, T?)`
 <!-- tc:scope public -->
 <!-- tc:version 1.0.0 -->
+Draws a quadratic Bezier curve using the specified origin and curve definition.
+
 
 ```csharp
 public void DrawBezierCurve(Vector3 origin, BezierCurve curve,
@@ -66,16 +83,23 @@ public void DrawBezierCurve(Vector3 origin, BezierCurve curve,
 
 **Parameters** <br>
 `origin` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `curve` [BezierCurve](/noir/reference/Noir/BezierCurve/) <br>
+ <br>
 `numberOfPoints` [int](https://learn.microsoft.com/en-us/dotnet/api/System.Int32?view=net-7.0) <br>
+ <br>
 `pointRadius` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 `direction` [T?](https://learn.microsoft.com/en-us/dotnet/api/System.Nullable-1?view=net-7.0) <br>
+ <br>
 
 <a name="DrawLinesToTargets"></a>
 
 ### `DrawLinesToTargets(GameObject, UnityEvent, Vector3)`
 <!-- tc:scope public -->
 <!-- tc:version 1.0.0 -->
+Draws dotted lines from a parent GameObject to the targets of a UnityEvent in the Unity Editor.
+
 
 ```csharp
 public void DrawLinesToTargets(GameObject parent, UnityEvent ev, Vector3 offset)
@@ -84,14 +108,20 @@ public void DrawLinesToTargets(GameObject parent, UnityEvent ev, Vector3 offset)
 
 **Parameters** <br>
 `parent` [GameObject](https://docs.unity3d.com/ScriptReference/GameObject.html) <br>
+ <br>
 `ev` [UnityEvent](https://docs.unity3d.com/ScriptReference/Events.UnityEvent.html) <br>
+ <br>
 `offset` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 
 <a name="DrawTypeIcon"></a>
 
 ### `DrawTypeIcon(Vector3, string, float)`
 <!-- tc:scope public -->
 <!-- tc:version 1.0.0 -->
+Draws an icon and label for the specified type at the given position in the scene view.
+            Only works in the Unity Editor.
+
 
 ```csharp
 public void DrawTypeIcon(Vector3 position, string label, float iconSize)
@@ -100,8 +130,11 @@ public void DrawTypeIcon(Vector3 position, string label, float iconSize)
 
 **Parameters** <br>
 `position` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `label` [string](https://learn.microsoft.com/en-us/dotnet/api/System.String?view=net-7.0) <br>
+ <br>
 `iconSize` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 
 <a name="DrawWireArc"></a>
 
@@ -135,6 +168,8 @@ public void DrawWireArc(Vector3 position, Vector3 dir, float anglesRange,
 ### `DrawWireCircle(Vector3, float, int)`
 <!-- tc:scope public -->
 <!-- tc:version 1.0.0 -->
+Draws a wireframe circle at the specified center and radius, oriented upwards.
+
 
 ```csharp
 public void DrawWireCircle(Vector3 circleCenter, float circleRadius,
@@ -145,14 +180,19 @@ public void DrawWireCircle(Vector3 circleCenter, float circleRadius,
 
 **Parameters** <br>
 `circleCenter` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `circleRadius` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 `segments` [int](https://learn.microsoft.com/en-us/dotnet/api/System.Int32?view=net-7.0) <br>
+ <br>
 
 <a name="DrawWireCircle"></a>
 
 ### `DrawWireCircle(Vector3, float, Vector3, int)`
 <!-- tc:scope public -->
 <!-- tc:version 1.0.0 -->
+Draws a wireframe circle at the specified center, radius, and normal direction.
+
 
 ```csharp
 public void DrawWireCircle(Vector3 circleCenter, float circleRadius,
@@ -163,15 +203,21 @@ public void DrawWireCircle(Vector3 circleCenter, float circleRadius,
 
 **Parameters** <br>
 `circleCenter` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `circleRadius` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 `circleNormal` [Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) <br>
+ <br>
 `segments` [int](https://learn.microsoft.com/en-us/dotnet/api/System.Int32?view=net-7.0) <br>
+ <br>
 
 <a name="DrawX"></a>
 
 ### `DrawX(Vector2, float)`
 <!-- tc:scope public -->
 <!-- tc:version 1.0.0 -->
+Draws an 'X' shape wireframe at a given 2D point.
+
 
 ```csharp
 public void DrawX(Vector2 point, float size)
@@ -180,5 +226,7 @@ public void DrawX(Vector2 point, float size)
 
 **Parameters** <br>
 `point` [Vector2](https://docs.unity3d.com/ScriptReference/Vector2.html) <br>
+ <br>
 `size` [float](https://learn.microsoft.com/en-us/dotnet/api/System.Single?view=net-7.0) <br>
+ <br>
 

--- a/docs/reference/Noir/NoirProjectConfiguration.md
+++ b/docs/reference/Noir/NoirProjectConfiguration.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Scriptable object that holds Noir project configuration settings and provides runtime access to them.
+
 
 ```csharp
 public class NoirProjectConfiguration : ScriptableObject
@@ -32,21 +34,11 @@ public NoirProjectConfiguration()
 <!-- tc:scope public -->
 <!-- tc:return_type AudioMixerGroup https://docs.unity3d.com/ScriptReference/Audio.AudioMixerGroup.html -->
 <!-- tc:version 1.0.0 -->
+Gets the default audio mixer group for the Noir project.
+
 
 ```csharp
 public AudioMixerGroup DefaultAudioMixerGroup { get; }
-
-```
-
-<a name="GameManagerPrefab"></a>
-
-### `GameManagerPrefab`
-<!-- tc:scope public -->
-<!-- tc:return_type NoirGameManager /noir/reference/Noir/NoirGameManager/ -->
-<!-- tc:version 1.0.0 -->
-
-```csharp
-public NoirGameManager GameManagerPrefab { get; }
 
 ```
 
@@ -56,6 +48,8 @@ public NoirGameManager GameManagerPrefab { get; }
 <!-- tc:scope public -->
 <!-- tc:return_type NoirProjectConfiguration /noir/reference/Noir/NoirProjectConfiguration/ -->
 <!-- tc:version 1.0.0 -->
+Gets the singleton instance of the NoirProjectConfiguration from project resources.
+
 
 ```csharp
 public static NoirProjectConfiguration Instance { get; }
@@ -68,6 +62,8 @@ public static NoirProjectConfiguration Instance { get; }
 <!-- tc:scope public -->
 <!-- tc:return_type bool https://learn.microsoft.com/en-us/dotnet/api/System.Boolean?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Gets a value indicating whether automatic spawning of game managers is enabled.
+
 
 ```csharp
 public bool IsAutomaticSpawnEnabled { get; }
@@ -80,6 +76,8 @@ public bool IsAutomaticSpawnEnabled { get; }
 <!-- tc:scope public -->
 <!-- tc:return_type bool https://learn.microsoft.com/en-us/dotnet/api/System.Boolean?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Gets a value indicating whether code generation is enabled.
+
 
 ```csharp
 public bool IsCodeGenerationEnabled { get; }
@@ -92,6 +90,8 @@ public bool IsCodeGenerationEnabled { get; }
 <!-- tc:scope public -->
 <!-- tc:return_type bool https://learn.microsoft.com/en-us/dotnet/api/System.Boolean?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Gets a value indicating whether the framerate is locked.
+
 
 ```csharp
 public bool IsFramerateLocked { get; }
@@ -104,6 +104,8 @@ public bool IsFramerateLocked { get; }
 <!-- tc:scope public -->
 <!-- tc:return_type int https://learn.microsoft.com/en-us/dotnet/api/System.Int32?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Gets the frame rate to lock the application to, if framerate locking is enabled.
+
 
 ```csharp
 public int LockedFrameRate { get; }

--- a/docs/reference/Noir/NoirSingletonBehaviour-1.md
+++ b/docs/reference/Noir/NoirSingletonBehaviour-1.md
@@ -4,6 +4,9 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Abstract base class for singleton behaviours in Noir.
+            Ensures that only one instance of type <typeparamref name="T" /> exists in the scene.
+
 
 ```csharp
 public abstract class NoirSingletonBehaviour<T> : NoirBehaviour
@@ -19,6 +22,9 @@ public abstract class NoirSingletonBehaviour<T> : NoirBehaviour
 <!-- tc:scope public -->
 <!-- tc:return_type T -->
 <!-- tc:version 1.0.0 -->
+Gets the singleton instance of type <typeparamref name="T" />.
+            Searches for an instance in the scene if not already set.
+
 
 ```csharp
 public static T Instance { get; }

--- a/docs/reference/Noir/ObjectExtensions.md
+++ b/docs/reference/Noir/ObjectExtensions.md
@@ -4,6 +4,8 @@
 
 <!-- tc:assembly Noir.dll -->
 
+Provides extension methods for safely converting objects to strings.
+
 
 ```csharp
 public static class ObjectExtensions
@@ -17,6 +19,8 @@ public static class ObjectExtensions
 <!-- tc:scope public -->
 <!-- tc:return_type string https://learn.microsoft.com/en-us/dotnet/api/System.String?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Returns the string representation of the object, or a custom string if the object is null.
+
 
 ```csharp
 public string ToStringSafe(Object o, Func<T, TResult> valueDelegate)
@@ -25,7 +29,9 @@ public string ToStringSafe(Object o, Func<T, TResult> valueDelegate)
 
 **Parameters** <br>
 `o` [Object](https://learn.microsoft.com/en-us/dotnet/api/System.Object?view=net-7.0) <br>
+ <br>
 `valueDelegate` [Func\<T, TResult\>](https://learn.microsoft.com/en-us/dotnet/api/System.Func-2?view=net-7.0) <br>
+ <br>
 
 <a name="ToStringSafe"></a>
 
@@ -33,6 +39,8 @@ public string ToStringSafe(Object o, Func<T, TResult> valueDelegate)
 <!-- tc:scope public -->
 <!-- tc:return_type string https://learn.microsoft.com/en-us/dotnet/api/System.String?view=net-7.0 -->
 <!-- tc:version 1.0.0 -->
+Returns the string representation of the object, or "NULL" if the object is null.
+
 
 ```csharp
 public string ToStringSafe(Object o)
@@ -41,4 +49,5 @@ public string ToStringSafe(Object o)
 
 **Parameters** <br>
 `o` [Object](https://learn.microsoft.com/en-us/dotnet/api/System.Object?view=net-7.0) <br>
+ <br>
 

--- a/package/Runtime/Noir/BezierCurveMovement.cs
+++ b/package/Runtime/Noir/BezierCurveMovement.cs
@@ -1,9 +1,20 @@
 ﻿using System;
 
 namespace Noir {
+    /// <summary>
+    /// Represents movement along a Bezier curve over a specified duration.
+    /// </summary>
     [Serializable]
     public class BezierCurveMovement {
+
+        /// <summary>
+        /// Gets or sets the Bezier curve to use for movement.
+        /// </summary>
         public BezierCurve Curve { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration of the movement along the curve, in seconds.
+        /// </summary>
         public float Duration { get; set; }
     }
 }

--- a/package/Runtime/Noir/Collections.cs
+++ b/package/Runtime/Noir/Collections.cs
@@ -1,14 +1,17 @@
 ﻿using System;
 
 namespace Noir {
+    /// <summary>
+    /// Provides extension methods and utilities for working with collections.
+    /// </summary>
     public static class Collections {
         /// <summary>
-        /// Performs an insertion sort on the given collection.
+        /// Performs an insertion sort on the given array up to the specified length.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="array"></param>
-        /// <param name="length"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">The type of elements in the array. Must implement <see cref="IComparable{T}"/> and <see cref="IEquatable{T}"/>.</typeparam>
+        /// <param name="array">The array to sort.</param>
+        /// <param name="length">The number of elements to sort from the start of the array.</param>
+        /// <returns>The sorted array.</returns>
         public static T[] Sort<T>(T[] array, int length) where T : IComparable<T>, IEquatable<T> {
             for (int i = 1; i < length; i++) {
                 var key = array[i];

--- a/package/Runtime/Noir/Collider2DExtensions.cs
+++ b/package/Runtime/Noir/Collider2DExtensions.cs
@@ -2,7 +2,25 @@
 using UnityEngine;
 
 namespace Noir {
+    /// <summary>
+    /// Extension methods for Unity <see cref="Collider2D"/> components.
+    /// </summary>
     public static class Collider2DExtensions {
+        /// <summary>
+        /// Sets the dimensions of the 2D collider based on the specified size.
+        /// The behavior depends on the specific collider type:
+        /// <list type="bullet">
+        /// <item><see cref="BoxCollider2D"/>: Sets the size property.</item>
+        /// <item><see cref="CircleCollider2D"/>: Sets the radius to the x value of the size.</item>
+        /// <item><see cref="CapsuleCollider2D"/>: Sets the size property.</item>
+        /// <item><see cref="PolygonCollider2D"/>: Throws an exception as dimensions cannot be set directly.</item>
+        /// </list>
+        /// </summary>
+        /// <param name="collider">The 2D collider to modify.</param>
+        /// <param name="size">The size parameters to apply.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when called on a <see cref="PolygonCollider2D"/>, as dimensions cannot be set.
+        /// </exception>
         public static void SetDimensions(this Collider2D collider, Vector2 size) {
             if (collider is BoxCollider2D boxCollider) {
                 boxCollider.size = size;

--- a/package/Runtime/Noir/ColliderExtensions.cs
+++ b/package/Runtime/Noir/ColliderExtensions.cs
@@ -2,7 +2,24 @@
 using UnityEngine;
 
 namespace Noir {
+    /// <summary>
+    /// Extension methods for Unity <see cref="Collider"/> components.
+    /// </summary>
     public static class ColliderExtensions {
+        /// <summary>
+        /// Sets the dimensions of the collider based on the specified size.
+        /// The behavior depends on the specific collider type:
+        /// <list type="bullet">
+        /// <item><see cref="BoxCollider"/>: Sets the size to (x, y, x).</item>
+        /// <item><see cref="SphereCollider"/>: Sets the radius to x.</item>
+        /// <item><see cref="CapsuleCollider"/>: Sets the radius to x and the height to y.</item>
+        /// </list>
+        /// </summary>
+        /// <param name="collider">The collider to modify.</param>
+        /// <param name="size">The size parameters to apply.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the collider type is not supported by this method.
+        /// </exception>
         public static void SetDimensions(this Collider collider, Vector2 size) {
             switch (collider)
             {

--- a/package/Runtime/Noir/ColorExtensions.cs
+++ b/package/Runtime/Noir/ColorExtensions.cs
@@ -2,7 +2,17 @@
 using UnityEngine;
 
 namespace Noir {
+    /// <summary>
+    /// Extension methods for the <see cref="Color"/> type, including blending, vector conversion, and utility operations.
+    /// </summary>
     public static class ColorExtensions {
+        /// <summary>
+        /// Fades a color to another color over the specified duration, yielding after each frame.
+        /// </summary>
+        /// <param name="color">The starting color.</param>
+        /// <param name="colorb">The color to fade to.</param>
+        /// <param name="duration">Duration of the fade in seconds.</param>
+        /// <returns>An enumerator for coroutine-based fading.</returns>
         public static IEnumerator FadeTo(this Color color, Color colorb, float duration) {
             Vector4 delta = new Vector4(color.r - colorb.r, color.g - colorb.g, color.b - colorb.b, color.a - colorb.a);
             var pct = 0 / duration;
@@ -16,25 +26,65 @@ namespace Noir {
             }
         }
 
+        /// <summary>
+        /// Converts a <see cref="Vector4"/> to a <see cref="Color"/>.
+        /// </summary>
+        /// <param name="vector">The vector to convert.</param>
+        /// <returns>The corresponding <see cref="Color"/>.</returns>
         public static Color ToColor(this Vector4 vector) {
             return new Color(vector.x, vector.y, vector.z, vector.w);
         }
 
+        /// <summary>
+        /// Converts a <see cref="Color"/> to a <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>The corresponding <see cref="Vector4"/>.</returns>
         public static Vector4 ToVector4(this Color color) {
             return new Vector4(color.r, color.g, color.b, color.a);
         }
 
+        /// <summary>
+        /// Returns a new color with the alpha channel set to the specified value.
+        /// </summary>
+        /// <param name="color">The original color.</param>
+        /// <param name="alpha">Alpha value to set.</param>
+        /// <returns>A new color with updated alpha.</returns>
         public static Color WithAlpha(this Color color, float alpha) {
             return new Color(color.r, color.g, color.b, alpha);
         }
 
+        /// <summary>
+        /// Specifies blend modes for color blending operations.
+        /// </summary>
         public enum ColorBlendMode {
+            /// <summary>
+            /// Adds the colors together.
+            /// </summary>
             Additive,
+            /// <summary>
+            /// Multiplies the colors together.
+            /// </summary>
             Multiply,
+            /// <summary>
+            /// Divides the colors.
+            /// </summary>
             Divide,
+            /// <summary>
+            /// Subtracts one color from another.
+            /// </summary>
             Subtract,
+            /// <summary>
+            /// Uses the darker value from each color channel.
+            /// </summary>
             Darken,
+            /// <summary>
+            /// Uses the lighter value from each color channel.
+            /// </summary>
             Lighten,
+            /// <summary>
+            /// Applies overlay blending.
+            /// </summary>
             Overlay,
         }
 
@@ -106,6 +156,12 @@ namespace Noir {
             return b + s - 2 * b * s;
         }
 
+        /// <summary>
+        /// Returns a new color with the minimum values from each channel of two colors.
+        /// </summary>
+        /// <param name="c1">First color.</param>
+        /// <param name="c2">Second color.</param>
+        /// <returns>Color with min values from each channel.</returns>
         public static Color MinWith(this Color c1, Color c2) {
             var r = Mathf.Min(c1.r, c2.r);
             var g = Mathf.Min(c1.g, c2.g);
@@ -114,6 +170,12 @@ namespace Noir {
             return new Color(r, g, b, a);
         }
 
+        /// <summary>
+        /// Returns a new color with the maximum values from each channel of two colors.
+        /// </summary>
+        /// <param name="c1">First color.</param>
+        /// <param name="c2">Second color.</param>
+        /// <returns>Color with max values from each channel.</returns>
         public static Color MaxWith(this Color c1, Color c2) {
             var r = Mathf.Max(c1.r, c2.r);
             var g = Mathf.Max(c1.g, c2.g);
@@ -122,6 +184,13 @@ namespace Noir {
             return new Color(r, g, b, a);
         }
 
+        /// <summary>
+        /// Blends two colors using the specified blend mode.
+        /// </summary>
+        /// <param name="a">The base color.</param>
+        /// <param name="b">The blend color.</param>
+        /// <param name="mode">Blend mode to use.</param>
+        /// <returns>The blended color.</returns>
         public static Color BlendWith(this Color a, Color b, ColorBlendMode mode = ColorBlendMode.Multiply) {
             var c = new Color();
             switch (mode) {
@@ -134,10 +203,21 @@ namespace Noir {
             return c;
         }
 
+        /// <summary>
+        /// Lightens the color by blending with white at 50% alpha.
+        /// </summary>
+        /// <param name="a">The color to lighten.</param>
+        /// <returns>The lightened color.</returns>
         public static Color Lighten(this Color a) {
             return a.Lighten(Color.white.WithAlpha(0.5f));
         }
 
+        /// <summary>
+        /// Lightens the color by blending with another color.
+        /// </summary>
+        /// <param name="a">Base color.</param>
+        /// <param name="b">Color to lighten with.</param>
+        /// <returns>The lightened color.</returns>
         public static Color Lighten(this Color a, Color b) {
             Color c = new Color();
 
@@ -150,10 +230,21 @@ namespace Noir {
             return c;
         }
 
+        /// <summary>
+        /// Darkens the color by blending with black at 50% alpha.
+        /// </summary>
+        /// <param name="a">The color to darken.</param>
+        /// <returns>The darkened color.</returns>
         public static Color Darken(this Color a) {
             return a.Lighten(Color.black.WithAlpha(0.5f));
         }
 
+        /// <summary>
+        /// Darkens the color by blending with another color.
+        /// </summary>
+        /// <param name="a">Base color.</param>
+        /// <param name="b">Color to darken with.</param>
+        /// <returns>The darkened color.</returns>
         public static Color Darken(this Color a, Color b) {
             Color c = new Color();
 
@@ -167,6 +258,12 @@ namespace Noir {
             return c;
         }
 
+        /// <summary>
+        /// Applies an overlay blend between two colors.
+        /// </summary>
+        /// <param name="a">Base color.</param>
+        /// <param name="b">Overlay color.</param>
+        /// <returns>The overlay blended color.</returns>
         public static Color Overlay(this Color a, Color b) {
             Color c = new Color();
 
@@ -192,6 +289,12 @@ namespace Noir {
             return c;
         }
 
+        /// <summary>
+        /// Applies a hard light blend between two colors.
+        /// </summary>
+        /// <param name="a">Base color.</param>
+        /// <param name="b">Hard light color.</param>
+        /// <returns>The hard light blended color.</returns>
         public static Color HardLight(this Color a, Color b) {
             Color c = new Color();
 
@@ -204,6 +307,12 @@ namespace Noir {
             return c;
         }
 
+        /// <summary>
+        /// Applies a soft light blend between two colors.
+        /// </summary>
+        /// <param name="a">Base color.</param>
+        /// <param name="b">Soft light color.</param>
+        /// <returns>The soft light blended color.</returns>
         public static Color SoftLight(this Color a, Color b) {
             Color c = new Color();
 
@@ -216,6 +325,12 @@ namespace Noir {
             return c;
         }
 
+        /// <summary>
+        /// Applies a difference blend between two colors.
+        /// </summary>
+        /// <param name="a">Base color.</param>
+        /// <param name="b">Difference color.</param>
+        /// <returns>The difference blended color.</returns>
         public static Color Difference(this Color a, Color b) {
             Color c = new Color();
 
@@ -228,6 +343,12 @@ namespace Noir {
             return c;
         }
 
+        /// <summary>
+        /// Applies an exclusion blend between two colors.
+        /// </summary>
+        /// <param name="a">Base color.</param>
+        /// <param name="b">Exclusion color.</param>
+        /// <returns>The exclusion blended color.</returns>
         public static Color Exclusion(this Color a, Color b) {
             Color c = new Color();
 
@@ -240,83 +361,90 @@ namespace Noir {
             return c;
         }
 
+        /// <summary>
+        /// Converts a color to a <see cref="Vector3"/> using its RGBA channels.
+        /// </summary>
+        /// <param name="c">The color to convert.</param>
+        /// <returns>A <see cref="Vector3"/> with RGB values and alpha as Z.</returns>
         public static Vector3 ToVector3(this Color c) {
             return (Vector3)c.ToVector4();
         }
 
-        public static Vector2 XY(this Color c) {
-            return new Vector2(c.r, c.g);
-        }
-        public static Vector2 XZ(this Color c) {
-            return new Vector2(c.r, c.b);
-        }
-
-        public static Vector2 XW(this Color c) {
-            return new Vector2(c.r, c.a);
-        }
-
-        public static Vector2 YX(this Color c) {
-            return new Vector2(c.g, c.r);
-        }
-
-        public static Vector2 YZ(this Color c) {
-            return new Vector2(c.g, c.b);
-        }
-
-        public static Vector2 YW(this Color c) {
-            return new Vector2(c.g, c.a);
-        }
-
-        public static Vector2 ZX(this Color c) {
-            return new Vector2(c.b, c.r);
-        }
-
-        public static Vector2 ZY(this Color c) {
-            return new Vector2(c.b, c.g);
-        }
-
-        public static Vector2 ZW(this Color c) {
-            return new Vector2(c.b, c.a);
-        }
-
-        public static Vector2 XX(this Color c) {
-            return new Vector2(c.r, c.r);
-        }
-
-        public static Vector3 XXX(this Color c) {
-            return new Vector3(c.r, c.r, c.r);
-        }
-
-        public static Vector4 XXXX(this Color c) {
-            return new Vector4(c.r, c.r, c.r, c.r);
-        }
-
-        public static Vector2 YY(this Color c) {
-            return new Vector2(c.g, c.g);
-        }
-
-        public static Vector3 YYY(this Color c) {
-            return new Vector3(c.g, c.g, c.g);
-        }
-
-        public static Vector4 YYYY(this Color c) {
-            return new Vector4(c.g, c.g, c.g, c.g);
-        }
-
-        public static Vector2 ZZ(this Color c) {
-            return new Vector2(c.b, c.b);
-        }
-
-        public static Vector3 ZZZ(this Color c) {
-            return new Vector3(c.b, c.b, c.b);
-        }
-
-        public static Vector4 ZZZZ(this Color c) {
-            return new Vector4(c.b, c.b, c.b, c.b);
-        }
-
-        public static Vector3 XYZ(this Color c) {
-            return c.ToVector3();
-        }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the red and green channels.
+        /// </summary>
+        public static Vector2 XY(this Color c) { return new Vector2(c.r, c.g); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the red and blue channels.
+        /// </summary>
+        public static Vector2 XZ(this Color c) { return new Vector2(c.r, c.b); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the red and alpha channels.
+        /// </summary>
+        public static Vector2 XW(this Color c) { return new Vector2(c.r, c.a); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the green and red channels.
+        /// </summary>
+        public static Vector2 YX(this Color c) { return new Vector2(c.g, c.r); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the green and blue channels.
+        /// </summary>
+        public static Vector2 YZ(this Color c) { return new Vector2(c.g, c.b); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the green and alpha channels.
+        /// </summary>
+        public static Vector2 YW(this Color c) { return new Vector2(c.g, c.a); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the blue and red channels.
+        /// </summary>
+        public static Vector2 ZX(this Color c) { return new Vector2(c.b, c.r); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the blue and green channels.
+        /// </summary>
+        public static Vector2 ZY(this Color c) { return new Vector2(c.b, c.g); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the blue and alpha channels.
+        /// </summary>
+        public static Vector2 ZW(this Color c) { return new Vector2(c.b, c.a); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the red channel twice.
+        /// </summary>
+        public static Vector2 XX(this Color c) { return new Vector2(c.r, c.r); }
+        /// <summary>
+        /// Gets a <see cref="Vector3"/> containing the red channel three times.
+        /// </summary>
+        public static Vector3 XXX(this Color c) { return new Vector3(c.r, c.r, c.r); }
+        /// <summary>
+        /// Gets a <see cref="Vector4"/> containing the red channel four times.
+        /// </summary>
+        public static Vector4 XXXX(this Color c) { return new Vector4(c.r, c.r, c.r, c.r); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the green channel twice.
+        /// </summary>
+        public static Vector2 YY(this Color c) { return new Vector2(c.g, c.g); }
+        /// <summary>
+        /// Gets a <see cref="Vector3"/> containing the green channel three times.
+        /// </summary>
+        public static Vector3 YYY(this Color c) { return new Vector3(c.g, c.g, c.g); }
+        /// <summary>
+        /// Gets a <see cref="Vector4"/> containing the green channel four times.
+        /// </summary>
+        public static Vector4 YYYY(this Color c) { return new Vector4(c.g, c.g, c.g, c.g); }
+        /// <summary>
+        /// Gets a <see cref="Vector2"/> containing the blue channel twice.
+        /// </summary>
+        public static Vector2 ZZ(this Color c) { return new Vector2(c.b, c.b); }
+        /// <summary>
+        /// Gets a <see cref="Vector3"/> containing the blue channel three times.
+        /// </summary>
+        public static Vector3 ZZZ(this Color c) { return new Vector3(c.b, c.b, c.b); }
+        /// <summary>
+        /// Gets a <see cref="Vector4"/> containing the blue channel four times.
+        /// </summary>
+        public static Vector4 ZZZZ(this Color c) { return new Vector4(c.b, c.b, c.b, c.b); }
+        /// <summary>
+        /// Gets a <see cref="Vector3"/> containing the red, green, and blue channels.
+        /// </summary>
+        public static Vector3 XYZ(this Color c) { return c.ToVector3(); }
     }
 }

--- a/package/Runtime/Noir/DictionaryExtensions.cs
+++ b/package/Runtime/Noir/DictionaryExtensions.cs
@@ -1,11 +1,29 @@
 ﻿using System.Collections.Generic;
 
 namespace Noir {
+    /// <summary>
+    /// Provides extension methods for performing upsert operations on <see cref="Dictionary{TKey, TValue}"/>.
+    /// </summary>
     public static class DictionaryExtensions {
+        /// <summary>
+        /// Inserts a key-value pair into the dictionary, or updates the value if the key already exists.
+        /// </summary>
+        /// <typeparam name="T">The type of the keys in the dictionary.</typeparam>
+        /// <typeparam name="K">The type of the values in the dictionary.</typeparam>
+        /// <param name="dict">The dictionary to operate on.</param>
+        /// <param name="kvp">The key-value pair to upsert.</param>
         public static void Upsert<T, K>(this Dictionary<T, K> dict, KeyValuePair<T, K> kvp) {
             dict.Upsert(kvp.Key, kvp.Value);
         }
 
+        /// <summary>
+        /// Inserts a key and value into the dictionary, or updates the value if the key already exists.
+        /// </summary>
+        /// <typeparam name="T">The type of the keys in the dictionary.</typeparam>
+        /// <typeparam name="K">The type of the values in the dictionary.</typeparam>
+        /// <param name="dict">The dictionary to operate on.</param>
+        /// <param name="key">The key to upsert.</param>
+        /// <param name="value">The value to upsert.</param>
         public static void Upsert<T, K>(this Dictionary<T, K> dict, T key, K value) {
             if (dict.ContainsKey(key)) {
                 dict[key] = value;
@@ -14,6 +32,13 @@ namespace Noir {
             dict.Add(key, value);
         }
 
+        /// <summary>
+        /// Inserts or updates multiple key-value pairs from another dictionary into the target dictionary.
+        /// </summary>
+        /// <typeparam name="T">The type of the keys in the dictionaries.</typeparam>
+        /// <typeparam name="K">The type of the values in the dictionaries.</typeparam>
+        /// <param name="target">The target dictionary to receive upserts.</param>
+        /// <param name="source">The source dictionary providing key-value pairs.</param>
         public static void Upsert<T, K>(this Dictionary<T, K> target, IDictionary<T, K> source) {
             foreach (var entry in source) {
                 target.Upsert(entry);

--- a/package/Runtime/Noir/Directions.cs
+++ b/package/Runtime/Noir/Directions.cs
@@ -7,8 +7,17 @@ namespace Noir {
     /// </summary>
     [Serializable]
     public enum HorizontalDirections : int {
+        /// <summary>
+        /// Right direction along the X-axis.
+        /// </summary>
         Right = 1,
+        /// <summary>
+        /// No direction along the X-axis.
+        /// </summary>
         None = 0,
+        /// <summary>
+        /// Left direction along the X-axis.
+        /// </summary>
         Left = -1,
     }
 
@@ -17,8 +26,17 @@ namespace Noir {
     /// </summary>
     [Serializable]
     public enum VerticalDirections : int {
+        /// <summary>
+        /// Up direction along the Y-axis.
+        /// </summary>
         Up = 1,
+        /// <summary>
+        /// No direction along the Y-axis.
+        /// </summary>
         None = 0,
+        /// <summary>
+        /// Down direction along the Y-axis.
+        /// </summary>
         Down = -1,
     }
 
@@ -27,8 +45,17 @@ namespace Noir {
     /// </summary>
     [Serializable]
     public enum PerpendicularDirections : int {
+        /// <summary>
+        /// Forward direction along the Z-axis.
+        /// </summary>
         Forward = 1,
+        /// <summary>
+        /// No direction along the Z-axis.
+        /// </summary>
         None = 0,
+        /// <summary>
+        /// Backward direction along the Z-axis.
+        /// </summary>
         Backward = -1,
     }
 
@@ -103,14 +130,27 @@ namespace Noir {
         /// </value>
         public PerpendicularDirections Perpendicular { get; private set; }
 
+        /// <summary>
+        /// Determines whether this instance and another <see cref="Direction"/> are equal.
+        /// </summary>
+        /// <param name="other">The other direction to compare.</param>
+        /// <returns><c>true</c> if the directions are equal; otherwise, <c>false</c>.</returns>
         public bool Equals(Direction other) {
             return other.Horizontal == Horizontal && other.Vertical == Vertical && other.Perpendicular == Perpendicular;
         }
 
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
         public override int GetHashCode() {
             return HashCode.Combine(Horizontal, Vertical, Perpendicular);
         }
 
+        /// <summary>
+        /// Determines whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with this direction.</param>
+        /// <returns><c>true</c> if the object is a <see cref="Direction"/> and is equal; otherwise, <c>false</c>.</returns>
         public override bool Equals(object obj) {
             if (obj is Direction d) {
                 return Equals(d);
@@ -118,13 +158,44 @@ namespace Noir {
             return base.Equals(obj);
         }
 
+        /// <summary>
+        /// Converts a <see cref="Direction"/> to a <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="d">The direction to convert.</param>
         public static implicit operator Vector2(Direction d) => new Vector2((int)d.Horizontal, (int)d.Vertical);
+
+        /// <summary>
+        /// Converts a <see cref="Vector2"/> to a <see cref="Direction"/>.
+        /// </summary>
+        /// <param name="v">The vector to convert.</param>
         public static explicit operator Direction(Vector2 v) => new Direction(v);
 
+        /// <summary>
+        /// Converts a <see cref="Direction"/> to a <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="d">The direction to convert.</param>
         public static implicit operator Vector3(Direction d) => new Vector3((int)d.Horizontal, (int)d.Vertical, (int)d.Perpendicular);
+
+        /// <summary>
+        /// Converts a <see cref="Vector3"/> to a <see cref="Direction"/>.
+        /// </summary>
+        /// <param name="v">The vector to convert.</param>
         public static explicit operator Direction(Vector3 v) => new Direction(v);
 
+        /// <summary>
+        /// Determines whether two <see cref="Direction"/> instances are equal.
+        /// </summary>
+        /// <param name="a">The first direction.</param>
+        /// <param name="b">The second direction.</param>
+        /// <returns><c>true</c> if the directions are equal; otherwise, <c>false</c>.</returns>
         public static bool operator ==(Direction a, Direction b) => a.Equals(b);
+
+        /// <summary>
+        /// Determines whether two <see cref="Direction"/> instances are not equal.
+        /// </summary>
+        /// <param name="a">The first direction.</param>
+        /// <param name="b">The second direction.</param>
+        /// <returns><c>true</c> if the directions are not equal; otherwise, <c>false</c>.</returns>
         public static bool operator !=(Direction a, Direction b) => !a.Equals(b);
     }
 }

--- a/package/Runtime/Noir/GameObjectExtensions.cs
+++ b/package/Runtime/Noir/GameObjectExtensions.cs
@@ -2,6 +2,9 @@
 using UnityEngine;
 
 namespace Noir {
+    /// <summary>
+    /// Provides extension methods and utilities for working with GameObjects.
+    /// </summary>
     public static class GameObjectExtensions {
         /// <summary>
         /// Gets the current GameObjects hierarchy as a path expression.


### PR DESCRIPTION
<!-- Please also consider adding yourself to CONTRIBUTORS.md as part of your pull request. We'd like to recognise you for your efforts! -->
<!-- Use the labels to mark what kind of PR you are submitting, bugfix? enhancement? docs? -->

## Overview

Adds a job to the `build.yaml` GitHub Action that reports the current amount of public API documentation within the Noir and NoirEditor libraries. Documentation coverage is generated by [Cranky](https://github.com/ricardoboss/cranky).

## Release Notes
<!-- Add any release notes for the changelog below -->
```release_note
- ci: adds api doc coverage % reporting to GHA build
```
