### PR TITLE
fix(ci): labeler should apply the ci label correctly now

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@ documentation:
 
 ci:
 - changed-files:
-  - any-glob-to-any-file: ['.github/*']
+  - any-glob-to-any-file: ['.github/**/*']
 
 unity:
 - changed-files:


### PR DESCRIPTION
<!-- Please also consider adding yourself to CONTRIBUTORS.md as part of your pull request. We'd like to recognise you for your efforts! -->
<!-- Use the labels to mark what kind of PR you are submitting, bugfix? enhancement? docs? -->

## Overview

Updates the labeler config YAML so that any pull-request that modifies files under the `.github/` folder will be labeled with the "CI" label.

## Release Notes
<!-- Add any release notes for the changelog below -->
```release_note
- fix(ci): labeler should apply the ci label correctly now
```
